### PR TITLE
Filter out query name starts with slash.

### DIFF
--- a/src/RememberQueryStrings.php
+++ b/src/RememberQueryStrings.php
@@ -12,7 +12,11 @@ class RememberQueryStrings
             return $next($request);
         }
 
-        if (empty($request->all())) {
+        $queryFiltered = array_filter($request->all(), function ($key) {
+            return ! str_starts_with($key, '/');
+        }, ARRAY_FILTER_USE_KEY);
+        
+        if (empty($queryFiltered)) {
             return $this->remembered($next, $request);
         }
 


### PR DESCRIPTION
When host application as a subdirectory ('example.com/myblog'), the `$request` also captures last path of the url like `/posts` as a data.

Remove them to make it works as expect for this use case.